### PR TITLE
Use opacity, not visibility to hide element

### DIFF
--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -262,7 +262,7 @@ uis.directive('uiSelect',
             }
 
             // Hide the dropdown so there is no flicker until $timeout is done executing.
-            dropdown[0].style.visibility = 'hidden';
+            dropdown[0].style.opacity = 0;
 
             // Delay positioning the dropdown until all choices have been added so its height is correct.
             $timeout(function(){
@@ -277,7 +277,7 @@ uis.directive('uiSelect',
               }
 
               // Display the dropdown once it has been positioned.
-              dropdown[0].style.visibility = '';
+              dropdown[0].style.opacity = 1;
             });
           } else {
               if (dropdown === null) {


### PR DESCRIPTION
Resolves #1032 by hiding the element with opacity, not
visibility. Elements with an opacity of 0 can still be focused.
